### PR TITLE
V3

### DIFF
--- a/portfolio/src/components/ToolBar/ToolBarOption/toolBarOption.astro
+++ b/portfolio/src/components/ToolBar/ToolBarOption/toolBarOption.astro
@@ -45,9 +45,6 @@ const props = Astro.props as IToolBarOption;
 			opacity: 0;
 		}
 
-		.icon-wrapper:hover .hover-label {
-			opacity: 1;
-		}
 		.small {
 			height: 5vh !important;
 			width: 5vh !important;

--- a/portfolio/src/components/ToolBar/toolbar.astro
+++ b/portfolio/src/components/ToolBar/toolbar.astro
@@ -68,6 +68,7 @@ const props = Astro.props as IToolBarProps;
 	height: auto;
 	margin: 10px 0;
 	background-color: rgb(172, 172, 172);
+	color: rgba(0,0,0,0)
 }
 
 </style>

--- a/portfolio/src/components/ToolBar/toolbar.astro
+++ b/portfolio/src/components/ToolBar/toolbar.astro
@@ -76,7 +76,6 @@ const props = Astro.props as IToolBarProps;
 	// Add all the click event listeners for the ToolBar
 	const toolBarOptionElements = document.getElementsByClassName("tool-bar-option");
 	Array.from(toolBarOptionElements).forEach(option => {
-		console.log("Adding event listener")
 		option.addEventListener("click", toggleApplicationView)
 	})
 </script>


### PR DESCRIPTION
Couple of quick fixes with mobile (no hover labels and removed the '|' in the vertical bar of tool bar)
